### PR TITLE
Implement fighter CRUD and stats

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,4 @@
 import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
 import { FightersModule } from './fighters/fighters.module';
 import { EventsModule } from './events/events.module';
 import { FightsModule } from './fights/fights.module';
@@ -23,13 +21,12 @@ import { GraphQLJSONObject } from 'graphql-type-json';
     }),
 
     GraphQLModule.forRoot({
-      driver: ApolloDriver, 
+      driver: ApolloDriver,
       autoSchemaFile: 'schema.gql',
       sortSchema: true,
-      resolvers: {                       
-        JSONObject: GraphQLJSONObject,          
+      resolvers: {
+        JSONObject: GraphQLJSONObject,
       },
-
     }),
 
     FightersModule,

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,15 +1,9 @@
 import { DataSource } from 'typeorm';
-import { Fighter } from './fighters/entities/fighter.entity';
-import { Event }   from './events/entities/event.entity';
-import { Fight }   from './fights/entities/fight.entity';
-import { Ranking } from './rankings/entities/ranking.entity';
 
 export const AppDataSource = new DataSource({
   type: 'postgres',
-  url:  process.env.DATABASE_URL,
+  url: process.env.DATABASE_URL,
   entities: [__dirname + '/**/*.entity.{ts,js}'],
   migrations: [__dirname + '/migrations/*.{ts,js}'],
   synchronize: false,
-  
 });
-

--- a/src/events/dto/create-event.input.ts
+++ b/src/events/dto/create-event.input.ts
@@ -1,8 +1,24 @@
-import { InputType, Int, Field } from '@nestjs/graphql';
+import { InputType, Field } from '@nestjs/graphql';
+import {
+  IsDateString,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 @InputType()
 export class CreateEventInput {
-  @Field() title: string;
-  @Field() eventDate: string;       
-  @Field({ nullable: true }) location?: string;
+  @Field()
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @Field()
+  @IsDateString()
+  eventDate: string;
+
+  @Field({ nullable: true })
+  @IsString()
+  @IsOptional()
+  location?: string;
 }

--- a/src/fighters/dto/create-fighter.input.ts
+++ b/src/fighters/dto/create-fighter.input.ts
@@ -1,11 +1,37 @@
 import { InputType, Int, Field } from '@nestjs/graphql';
+import { IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
 
 @InputType()
 export class CreateFighterInput {
-  @Field() fullName: string;
-  @Field() weightClass: string;
-  @Field(() => Int, { defaultValue: 0 }) knockouts?: number;
-  @Field(() => Int, { defaultValue: 0 }) submissions?: number;
-  @Field({ nullable: true }) nationality?: string;
-  @Field({ nullable: true }) team?: string;
+  @Field()
+  @IsString()
+  @IsNotEmpty()
+  fullName: string;
+
+  @Field()
+  @IsString()
+  @IsNotEmpty()
+  weightClass: string;
+
+  @Field(() => Int, { defaultValue: 0 })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  knockouts?: number;
+
+  @Field(() => Int, { defaultValue: 0 })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  submissions?: number;
+
+  @Field({ nullable: true })
+  @IsString()
+  @IsOptional()
+  nationality?: string;
+
+  @Field({ nullable: true })
+  @IsString()
+  @IsOptional()
+  team?: string;
 }

--- a/src/fighters/entities/fighter-stats.entity.ts
+++ b/src/fighters/entities/fighter-stats.entity.ts
@@ -1,0 +1,16 @@
+import { ObjectType, Field, Int } from '@nestjs/graphql';
+
+@ObjectType()
+export class FighterStats {
+  @Field(() => Int)
+  wins: number;
+
+  @Field(() => Int)
+  losses: number;
+
+  @Field(() => Int)
+  knockouts: number;
+
+  @Field(() => Int)
+  submissions: number;
+}

--- a/src/fighters/fighters.resolver.ts
+++ b/src/fighters/fighters.resolver.ts
@@ -1,6 +1,7 @@
 import { Resolver, Query, Mutation, Args, Int } from '@nestjs/graphql';
 import { FightersService } from './fighters.service';
 import { Fighter } from './entities/fighter.entity';
+import { FighterStats } from './entities/fighter-stats.entity';
 import { CreateFighterInput } from './dto/create-fighter.input';
 import { UpdateFighterInput } from './dto/update-fighter.input';
 
@@ -10,12 +11,31 @@ export class FightersResolver {
 
   @Mutation(() => Fighter)
   createFighter(@Args('input') input: CreateFighterInput) {
-    return this.service.create(input);       
+    return this.service.create(input);
   }
-
 
   @Query(() => [Fighter])
   fighters() {
     return this.service.findAll();
+  }
+
+  @Query(() => Fighter)
+  fighter(@Args('id', { type: () => Int }) id: number) {
+    return this.service.findOne(id);
+  }
+
+  @Query(() => FighterStats)
+  fighterStats(@Args('id', { type: () => Int }) id: number) {
+    return this.service.stats(id);
+  }
+
+  @Mutation(() => Fighter)
+  updateFighter(@Args('input') input: UpdateFighterInput) {
+    return this.service.update(input.id, input);
+  }
+
+  @Mutation(() => Fighter)
+  removeFighter(@Args('id', { type: () => Int }) id: number) {
+    return this.service.remove(id);
   }
 }

--- a/src/fighters/fighters.service.ts
+++ b/src/fighters/fighters.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateFighterInput } from './dto/create-fighter.input';
 import { UpdateFighterInput } from './dto/update-fighter.input';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -18,5 +18,34 @@ export class FightersService {
 
   findAll() {
     return this.repo.find();
+  }
+
+  async findOne(id: number) {
+    const fighter = await this.repo.findOneBy({ id });
+    if (!fighter)
+      throw new NotFoundException(`Fighter with id ${id} not found`);
+    return fighter;
+  }
+
+  async update(id: number, dto: UpdateFighterInput) {
+    const fighter = await this.findOne(id);
+    Object.assign(fighter, dto);
+    return this.repo.save(fighter);
+  }
+
+  async remove(id: number) {
+    const fighter = await this.findOne(id);
+    await this.repo.delete(id);
+    return fighter;
+  }
+
+  async stats(id: number) {
+    const fighter = await this.findOne(id);
+    return {
+      wins: fighter.wins,
+      losses: fighter.losses,
+      knockouts: fighter.knockouts,
+      submissions: fighter.submissions,
+    };
   }
 }

--- a/src/fights/dto/create-fight.input.ts
+++ b/src/fights/dto/create-fight.input.ts
@@ -1,8 +1,31 @@
 import { InputType, Int, Field } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
+import {
+  IsArray,
+  ArrayNotEmpty,
+  IsInt,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
 
 @InputType()
 export class CreateFightInput {
-  @Field(() => Int) eventId: number;
-  @Field() weightClass: string;
-  @Field(() => [Int]) participantsIds: number[];
+  @Field(() => Int)
+  @IsInt()
+  @Min(1)
+  eventId: number;
+
+  @Field()
+  @IsString()
+  weightClass: string;
+
+  @Field(() => [Int])
+  @IsArray()
+  @ArrayNotEmpty()
+  participantsIds: number[];
+
+  @Field(() => GraphQLJSONObject, { nullable: true })
+  @IsOptional()
+  resultJson?: Record<string, unknown>;
 }

--- a/src/fights/dto/update-fight.input.ts
+++ b/src/fights/dto/update-fight.input.ts
@@ -1,8 +1,12 @@
 import { CreateFightInput } from './create-fight.input';
 import { InputType, Field, Int, PartialType } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
 
 @InputType()
 export class UpdateFightInput extends PartialType(CreateFightInput) {
   @Field(() => Int)
   id: number;
+
+  @Field(() => GraphQLJSONObject, { nullable: true })
+  resultJson?: Record<string, unknown>;
 }

--- a/src/fights/fights.service.ts
+++ b/src/fights/fights.service.ts
@@ -10,14 +10,12 @@ import { RankingsService } from 'src/rankings/rankings.service';
 
 @Injectable()
 export class FightsService {
-
   constructor(
-    @InjectRepository(Fight)   private fightRepo:   Repository<Fight>,
-    @InjectRepository(Event)   private eventRepo:   Repository<Event>,
+    @InjectRepository(Fight) private fightRepo: Repository<Fight>,
+    @InjectRepository(Event) private eventRepo: Repository<Event>,
     @InjectRepository(Fighter) private fighterRepo: Repository<Fighter>,
-    private readonly rankingsService: RankingsService
+    private readonly rankingsService: RankingsService,
   ) {}
-
 
   async create(dto: CreateFightInput) {
     const event = await this.eventRepo.findOne({ where: { id: dto.eventId } });
@@ -31,26 +29,59 @@ export class FightsService {
       weightClass: dto.weightClass,
       event,
       participants,
+      resultJson: dto.resultJson,
     });
 
-    if (fight.weightClass) {
-      await this.rankingsService.recalc(fight.weightClass);
+    const saved = await this.fightRepo.save(fight);
+
+    if (saved.weightClass) {
+      await this.rankingsService.recalc(saved.weightClass);
     }
-    
-    return this.fightRepo.save(fight);   
+
+    return saved;
   }
 
   async findAll() {
-    return this.fightRepo.find({ relations: ['event', 'participants'] }); 
+    return this.fightRepo.find({ relations: ['event', 'participants'] });
   }
 
   async findOne(id: number) {
-    return this.fightRepo.findOne({ where: { id }, relations: ['event', 'participants'] });
+    return this.fightRepo.findOne({
+      where: { id },
+      relations: ['event', 'participants'],
+    });
   }
 
   async update(id: number, updateFightInput: UpdateFightInput) {
-    await this.fightRepo.update(id, updateFightInput);
-    return this.findOne(id);
+    const fight = await this.findOne(id);
+    if (!fight) throw new NotFoundException('Fight not found');
+
+    if (updateFightInput.eventId) {
+      const event = await this.eventRepo.findOne({
+        where: { id: updateFightInput.eventId },
+      });
+      if (!event) throw new NotFoundException('Event not found');
+      fight.event = event;
+    }
+    if (updateFightInput.participantsIds) {
+      fight.participants = await this.fighterRepo.find({
+        where: { id: In(updateFightInput.participantsIds) },
+      });
+    }
+    if (updateFightInput.weightClass !== undefined) {
+      fight.weightClass = updateFightInput.weightClass;
+    }
+    if (updateFightInput.resultJson !== undefined) {
+      fight.resultJson = updateFightInput.resultJson;
+    }
+
+    const saved = await this.fightRepo.save(fight);
+
+    if (saved.weightClass) {
+      await this.rankingsService.recalc(saved.weightClass);
+    }
+
+    return saved;
   }
 
   async remove(id: number) {

--- a/src/rankings/dto/create-ranking.input.ts
+++ b/src/rankings/dto/create-ranking.input.ts
@@ -1,10 +1,20 @@
 import { InputType, Int, Field } from '@nestjs/graphql';
+import { IsInt, IsNotEmpty, IsString, Min } from 'class-validator';
 
 @InputType()
 export class CreateRankingInput {
-  @Field() weightClass: string;
+  @Field()
+  @IsString()
+  @IsNotEmpty()
+  weightClass: string;
 
-  @Field(() => Int) fighterId: number;
+  @Field(() => Int)
+  @IsInt()
+  @Min(1)
+  fighterId: number;
 
-  @Field(() => Int) position: number;
+  @Field(() => Int)
+  @IsInt()
+  @Min(1)
+  position: number;
 }


### PR DESCRIPTION
## Summary
- add validation decorators for DTOs
- implement fighter CRUD service and resolver
- expose fighter stats query
- recalc rankings when fights are updated

## Testing
- `npm run lint`
- `npm test`

